### PR TITLE
Add correct network configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,65 @@ variable "PRIVATE_KEY" {
     type = string
 }
 
+resource "aws_vpc" "mainvpc" {
+  cidr_block = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "public" {
+  vpc_id = aws_vpc.mainvpc.id
+  cidr_block = "10.0.0.0/24"
+  availability_zone = "us-west-2a"
+  tags = {
+    Name = "Default subnet for us-west-2a"
+  }
+}
+
+resource "aws_internet_gateway" "my_vpc_igw" {
+  vpc_id = aws_vpc.mainvpc.id
+  tags = {
+    Name = "Internet Gateway"
+  }
+}
+
+# Routes table, accept traffic from the outside world
+resource "aws_route_table" "my_vpc_us_west_2a_public" {
+    vpc_id = aws_vpc.mainvpc.id
+    route {
+        cidr_block = "0.0.0.0/0"
+        gateway_id = aws_internet_gateway.my_vpc_igw.id
+    }
+    tags = {
+        Name = "Public Subnet Route Table."
+    }
+}
+resource "aws_route_table_association" "my_vpc_us_west_2a_public" {
+    subnet_id = aws_subnet.public.id
+    route_table_id = aws_route_table.my_vpc_us_west_2a_public.id
+}
+
+
+resource "aws_security_group" "ingress-all" {
+  name = "allow-all-sg"
+  vpc_id = "${aws_vpc.mainvpc.id}"
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+  }
+
+  // Terraform removes the default rule
+  egress {
+   from_port = 0
+   to_port = 0
+   protocol = "-1"
+   cidr_blocks = ["0.0.0.0/0"]
+ }
+
+ }
+
 resource "aws_key_pair" "deployer" {
   key_name   = "deployer-key"
   public_key = "${file(var.PUBLIC_KEY)}"
@@ -28,9 +87,12 @@ resource "aws_key_pair" "deployer" {
 
 resource "aws_instance" "rlcone_ec2" {
   ami           = "ami-0fcf52bcf5db7b003"
+  count         = 4
   instance_type = "t2.micro"
-  key_name = aws_key_pair.deployer.key_name
-  count = 4
+  key_name      = aws_key_pair.deployer.key_name
+  vpc_security_group_ids = ["${aws_security_group.ingress-all.id}"]
+  subnet_id = aws_subnet.public.id
+  associate_public_ip_address = true
   tags = {
     Name = "RcloneScaleTestingServer"
   }
@@ -43,12 +105,7 @@ resource "aws_instance" "rlcone_ec2" {
     private_key = "${file(var.PRIVATE_KEY)}"
   }
 
-  provisioner "file" {
-    source      = "rclone.conf"
-    destination = ".config/rclone/rclone.conf"
-  }
-
-  provisioner "file" {
+   provisioner "file" {
     source      = "provision"
     destination = "/tmp/provision"
   }
@@ -57,8 +114,13 @@ resource "aws_instance" "rlcone_ec2" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /tmp/provision",
-      "sudo /tmp/setup-lnxcfg-user",
+      "sudo /tmp/provision",
     ]
+  }
+
+  provisioner "file" {
+    source      = "rclone.conf"
+    destination = ".config/rclone/rclone.conf"
   }
 
 }


### PR DESCRIPTION
Terraform removes to aws defaults that make it easy to create ec2 machines and ssh into them. It's the required to explicitly and those to allow public sshas well terraforms scp-based commands.