### PR TITLE
Correctly copy ready-made rclone config to host machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This means:
 - You have to [install rclone](https://rclone.org/install/) on a secured machine (Ideally the host from which this IaC is run)
 - Configure the [permanent remotes](https://rclone.org/remote_setup/) see [Running rclone against Permanent.org instances](https://github.com/permanentOrg/sftp-service/#running-rclone-against-permanentorg-instances) for more detailed information if any confusion arises.
 - Replace the contents of `rclone.conf` with the content of your local configuration from `~/.config/rclone/rclone.conf`
-### SSH Access
+### SSH access
 
 To be able to `ssh` into the created instances with your existing ssh-key pass the public part as described below.
 
@@ -28,6 +28,12 @@ Run `export TF_VAR_PUBLIC_KEY=~/.ssh/id_rsa.pub` you can also pass a custom path
 We also use [terraform provisioners](). This means a private key is needed by the provision to connect and execute the provision instructions hence pass the private part of your ssh-key as described below.
 
 Run `export TF_VAR_PRIVATE_KEY=~/.ssh/id_rsa` you can also pass a custom path for example `export TF_VAR_PRIVATE_KEY=custom/path/to/privkey`
+
+### Change number of machines
+
+The default number of machines that would be created is 1.
+
+Run `export TF_VAR_NUMBER_OF_MACHINES=4` (This example sets the number of machines to 5. *The counting starts from 0 :)*)
 
 ---
 - `terraform plan`

--- a/provision
+++ b/provision
@@ -4,16 +4,20 @@
 # Setup https://github.com/OpenTechStrategies/permanent-rclone-qa for tests
 
 sudo apt-get update
+sudo apt -y remove needrestart # Preventing script from getting stuck with message "Pending kernel upgrade"
 sudo apt -y upgrade
-sudo apt install software-properties-common
+sudo apt -y install software-properties-common
+sudo apt -y install python3-pip
 sudo apt -y install git
-sudo apt install rclone -y
+sudo apt -y install rclone
+rclone config file # Show loaded or prospective rclone config file
+rclone config touch # Create rclone config dir if does not exist
 cd ~
 git clone https://github.com/OpenTechStrategies/permanent-rclone-qa
 cd permanent-rclone-qa
 pip install -r requirements.txt
 ./create-files.py
 CURRENTDATETIME=`date +"%Y-%m-%d_%T"`
-echo "00 13 * * 1-5 ./upload-test.py test-tree/special-files/1000-1B --remote-dir=1000-10B-${CURRENTDATETIME}-parallel --log-file=log-1000-1B-${CURRENTDATETIME}.txt --remote=prod --archive-path='/archives/QA (0a21-0000)/My Files/'" >> uploadcron
+echo "00 13 * * 1-5 ~/permanent-rclone-qa/upload-test.py test-tree/special-files/1000-1B --remote-dir=1000-10B-${CURRENTDATETIME}-parallel --log-file=log-1000-1B-${CURRENTDATETIME}.txt --remote=prod --archive-path='/archives/QA (0a21-0000)/My Files/'" >> uploadcron
 crontab uploadcron
 rm uploadcron


### PR DESCRIPTION
For some reason the provision script was running as root and creating the rclone config directories in `/root` instead of `/home/ubuntu` which is the default user in this case.

- The home path specified to the file provision now contains the ssh user name.
- Provision script would not run as current user as it is now forced to using `sudo -u {username} /tmp/provision`
- Now use rclone commands to ensure config directories exist instead of creating them with `mkdir`