### PR TITLE
Fix upload source path

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Run `export TF_VAR_PRIVATE_KEY=~/.ssh/id_rsa` you can also pass a custom path fo
 
 The default number of machines that would be created is 1.
 
-Run `export TF_VAR_NUMBER_OF_MACHINES=4` (This example sets the number of machines to 5. *The counting starts from 0 :)*)
+Run `export TF_VAR_NUMBER_OF_MACHINES=5` (This example sets the number of machines to 5.)
 
 ---
 - `terraform plan`

--- a/provision
+++ b/provision
@@ -18,6 +18,6 @@ cd permanent-rclone-qa
 pip install -r requirements.txt
 ./create-files.py
 CURRENTDATETIME=`date +"%Y-%m-%d_%T"`
-echo "00 13 * * 1-5 ~/permanent-rclone-qa/upload-test.py test-tree/special-files/1000-1B --remote-dir=1000-10B-${CURRENTDATETIME}-parallel --log-file=log-1000-1B-${CURRENTDATETIME}.txt --remote=prod --archive-path='/archives/QA (0a21-0000)/My Files/'" >> uploadcron
+echo "00 13 * * 1-5 ~/permanent-rclone-qa/upload-test.py ~/permanent-rclone-qa/test-tree/special-files/1000-1B --remote-dir=1000-10B-${CURRENTDATETIME}-parallel --log-file=log-1000-1B-${CURRENTDATETIME}.txt --remote=prod --archive-path='/archives/QA (0a21-0000)/My Files/'" >> uploadcron
 crontab uploadcron
 rm uploadcron


### PR DESCRIPTION
We running the upload script using cron from the user's crontab this means we can't use relative paths as we would normally do with the qa repository, as it would lead to "404's" for paths.

This also corrects a misconception about how machines are counted in the docs.